### PR TITLE
Get branch name by keeping substring after origin/

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,7 +109,7 @@ func main() {
 				continue
 			}
 
-			branch = strings.Replace(branch, "origin/", "", -1)
+			branch = strings.Split(branch, "origin/")[1]
 
 			status, err := getStatus(jenkinsUrl, jenkinsUser, jenkinsPwd, job, b)
 			if err != nil {


### PR DESCRIPTION
In Jenkins, we need to add "GitHub Pull Request Builder" plugin.
This plugin has dependencies with "Git Client Plugin" and "Git Plugin" requiring them to upgrade their version.
This upgrade changes the name of the branch on JSON API Jenkins responses (http://<jenkins_url>/job/<job_name>/<build_number>/git/api/json; lastBuiltRevision.branch.name).

Thus, origin/branch_name is replaced by refs/remotes/origin/branch_name

This patch will work with both behaviors :)
